### PR TITLE
add benchmark

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const stringify = require('json-stringify-deterministic')
 const { default: hash } = require('stable-hash')
 const { escape } = require('base64-url')
 const hashObject = require('hash-obj')
@@ -64,6 +65,15 @@ const getHashTwo = obj => {
   )
 }
 
+const getHashThree = obj => {
+  return escape(
+    crypto
+      .createHash('sha512')
+      .update(stringify(flattie(obj)))
+      .digest('base64')
+  )
+}
+
 bench('`hash-obj` 200.000 times', function (b) {
   b.start()
 
@@ -79,6 +89,16 @@ bench('`stable-hash` 200.000 times', function (b) {
 
   for (let i = 0; i < 200000; i++) {
     getHashTwo(payload)
+  }
+
+  b.end()
+})
+
+bench('`json-stringify-deterministic` 200.000 times', function (b) {
+  b.start()
+
+  for (let i = 0; i < 200000; i++) {
+    getHashThree(payload)
   }
 
   b.end()

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const { default: hash } = require('stable-hash')
+const { escape } = require('base64-url')
+const hashObject = require('hash-obj')
+const { flattie } = require('flattie')
+const bench = require('nanobench')
+const crypto = require('crypto')
+
+// this is an exmaple of payload
+const payload = {
+  url: 'https://example.com/',
+  query: {
+    screenshot: true,
+    ttl: 86400000,
+    staleTtl: false,
+    prerender: 'auto',
+    meta: true,
+    data: false,
+    video: false,
+    audio: false,
+    pdf: false,
+    insights: false,
+    iframe: false,
+    ping: true,
+    headers: {
+      'upgrade-insecure-requests': '1',
+      dnt: '1',
+      accept: '*/*',
+      'sec-fetch-site': 'same-origin',
+      'sec-fetch-mode': 'navigate',
+      'sec-fetch-user': '?1',
+      'sec-fetch-dest': 'document',
+      'accept-encoding': 'gzip, deflate, br',
+      'accept-language': 'en'
+    }
+  }
+}
+
+/***
+ * benchamarking `hash-obj` vs. `stable-hash`
+ *
+ * The goal is to represent a real use-case. Because that:
+ *
+ * - ensure the input is flatten
+ * - output is base64 URL safe
+ * - sha512 is used as algorithm
+ *
+ */
+const getHashOne = obj =>
+  escape(
+    hashObject(flattie(obj), {
+      encoding: 'base64',
+      algorithm: 'sha512'
+    })
+  )
+
+const getHashTwo = obj => {
+  return escape(
+    crypto
+      .createHash('sha512')
+      .update(hash(flattie(obj)))
+      .digest('base64')
+  )
+}
+
+bench('`hash-obj` 200.000 times', function (b) {
+  b.start()
+
+  for (let i = 0; i < 200000; i++) {
+    getHashOne(payload)
+  }
+
+  b.end()
+})
+
+bench('`stable-hash` 200.000 times', function (b) {
+  b.start()
+
+  for (let i = 0; i < 200000; i++) {
+    getHashTwo(payload)
+  }
+
+  b.end()
+})


### PR DESCRIPTION
Hello,

I just wanted to check how fast `stable-hash` is.

This was the output:

```
# `hash-obj` 200.000 times
ok ~2.61 s (2 s + 608012333 ns)

# `stable-hash` 200.000 times
ok ~2.23 s (2 s + 228564833 ns)

# `json-stringify-deterministic` 200.000 times
ok ~2.65 s (2 s + 648474125 ns)

all benchmarks completed
ok ~7.49 s (7 s + 485051291 ns)
```

It could be nice to add into the repo 😆