### PR TITLE
Update exports/types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "exports": {
     "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "import": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist/**"


### PR DESCRIPTION
Fix error : Could not find a declaration file for module 'stable-hash'. 'node_modules/stable-hash/dist/index.mjs' implicitly has an 'any' type.
  There are types at 'node_modules/stable-hash/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'stable-hash' library may need to update its package.json or typings.ts(7016)